### PR TITLE
fix!: `MeasurementResult` class changes & custom exceptions

### DIFF
--- a/lib/flutter_anyline_tire_tread_scanner.dart
+++ b/lib/flutter_anyline_tire_tread_scanner.dart
@@ -1,4 +1,5 @@
 export 'src/core/anyline_tire_tread_scanner.dart';
+export 'src/core/exceptions.dart';
 export 'src/core/measurement_system.dart';
 export 'src/core/scanning_event.dart';
 export 'src/core/tread_depth_result.dart';

--- a/lib/src/core/exceptions.dart
+++ b/lib/src/core/exceptions.dart
@@ -1,0 +1,23 @@
+abstract class AnylineTireTreadScannerException {
+  const AnylineTireTreadScannerException({
+    required this.code,
+    required this.message,
+    required this.stackTrace,
+  });
+
+  final String code;
+  final String message;
+  final StackTrace stackTrace;
+}
+
+class GetTreadDepthReportResultFailed extends AnylineTireTreadScannerException {
+  const GetTreadDepthReportResultFailed({
+    required super.code,
+    required super.message,
+    required super.stackTrace,
+  });
+
+  @override
+  String toString() =>
+      "GetTreadDepthReportResultFailed(\ncode: $code,\nmessage: $message,\nstackTrace: ${stackTrace.toString()}\n)";
+}

--- a/lib/src/core/tread_depth_result.dart
+++ b/lib/src/core/tread_depth_result.dart
@@ -39,9 +39,9 @@ class MeasurementResult {
   });
 
   final double topTire;
-  final double leftTire;
-  final double middleTire;
-  final double rightTire;
+  final double? leftTire;
+  final double? middleTire;
+  final double? rightTire;
 
   factory MeasurementResult.fromMap(dynamic map) {
     return MeasurementResult(

--- a/lib/src/platform/flutter_anyline_tire_tread_scanner_method_channel.dart
+++ b/lib/src/platform/flutter_anyline_tire_tread_scanner_method_channel.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/services.dart';
+import 'package:flutter_anyline_tire_tread_scanner/src/core/exceptions.dart';
 
 import '../core/measurement_system.dart';
 import '../core/scanning_event.dart';
@@ -56,16 +57,28 @@ class AnylineTireTreadScannerMethodChannel extends AnylineTireTreadScannerPlatfo
     required String uuid,
     MeasurementSystem measurementSystem = MeasurementSystem.metric,
   }) async {
-    final result = await _methodChannel.invokeMethod(
-      'getTreadDepthResult',
-      {
-        'uuid': uuid,
-        'measurementSystem': measurementSystem.name,
-      },
-    );
+    try {
+      final result = await _methodChannel.invokeMethod(
+        'getTreadDepthResult',
+        {
+          'uuid': uuid,
+          'measurementSystem': measurementSystem.name,
+        },
+      );
 
-    if (result == null) return null;
+      if (result == null) return null;
 
-    return TreadDepthResult.fromMap(result!);
+      return TreadDepthResult.fromMap(result!);
+    } on PlatformException catch (e, strackTrace) {
+      if (e.code == "FlutterAnylineTireTreadGetTreadDepthReportResultFailed") {
+        throw GetTreadDepthReportResultFailed(
+          code: e.code,
+          message: e.message ?? "",
+          stackTrace: strackTrace,
+        );
+      } else {
+        rethrow;
+      }
+    }
   }
 }


### PR DESCRIPTION
`leftTire`, `middleTire` and `rightTire` now are nullable properties from `MeasurementResult` class.

`AnylineTireTreadScannerException` has been integrated for handling custom exceptions that can not be considered as a `PlatformException`.